### PR TITLE
Dependence to base_multi_image

### DIFF
--- a/connector_prestashop/__manifest__.py
+++ b/connector_prestashop/__manifest__.py
@@ -17,6 +17,7 @@
         "connector_ecommerce",  # oca/connector-ecommerce
         "purchase",
         "product_variant_supplierinfo",  # oca/product-variant
+        "base_multi_image", # oca/server-tools
     ],
     "external_dependencies": {
         'python': [

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -4,3 +4,4 @@ e-commerce
 product-attribute
 product-variant
 sale-workflow
+base_multi_image


### PR DESCRIPTION
There is a dependency to the module base_multi_image in the code that is not reflected.
Exactly in:
connector_prestashop / models / common.py
connector_prestashop / view / image_view.xml